### PR TITLE
Fix an Issue with placeholders in expressions when the declare license is also a placeholder

### DIFF
--- a/src/CdxEnrich.Tests/ClearlyDefined/LicenseResolverTests.cs
+++ b/src/CdxEnrich.Tests/ClearlyDefined/LicenseResolverTests.cs
@@ -41,6 +41,7 @@ namespace CdxEnrich.Tests.ClearlyDefined
                 foreach (var licensePlaceholderFromExpression in LicensePlaceholder.All)
                 {
                     yield return [licensePlaceholder, new[] { licensePlaceholderFromExpression.LicenseIdentifier }]; //One expression that is a license placeholder
+                    yield return [licensePlaceholder, new[] { $"MIT OR {licensePlaceholderFromExpression.LicenseIdentifier}" }]; //One expression contains a license placeholder
                 }
             }
         }

--- a/src/CdxEnrich/ClearlyDefined/LicensePlaceholder.cs
+++ b/src/CdxEnrich/ClearlyDefined/LicensePlaceholder.cs
@@ -39,18 +39,21 @@
         {
             return declared.Contains(LicenseIdentifier);
         }
-        
+
         /// <summary>
-        /// Tries to get a LicensePlaceholder by its license identifier.
+        /// Extracts a list of license placeholders that are contained within the specified license expression.
         /// </summary>
-        /// <param name="licenseIdentifier"></param>
-        /// <param name="licensePlaceholder"></param>
-        /// <returns></returns>
-        public static bool TryGetByLicenseIdentifier(string licenseIdentifier, out LicensePlaceholder? licensePlaceholder)
+        /// <param name="licenseExpression">The license expression to evaluate.</param>
+        /// <returns>A list of license placeholders found within the provided license expression.</returns>
+        public static IList<LicensePlaceholder> ExtractContaining(string? licenseExpression)
         {
-            licensePlaceholder = All.FirstOrDefault(x =>
-                x.LicenseIdentifier.Equals(licenseIdentifier, StringComparison.OrdinalIgnoreCase));
-            return licensePlaceholder != null;
+            if (licenseExpression == null)
+            {
+                return [];
+            }
+            
+            return All.Where(x => licenseExpression.Contains(x.LicenseIdentifier, StringComparison.OrdinalIgnoreCase))
+                .ToList();
         }
 
         // For records, ToString() is automatically overridden and returns a formatted string with all properties

--- a/src/CdxEnrich/ClearlyDefined/Rules/PlaceholderLicenseResolveRule.cs
+++ b/src/CdxEnrich/ClearlyDefined/Rules/PlaceholderLicenseResolveRule.cs
@@ -28,13 +28,12 @@ namespace CdxEnrich.ClearlyDefined.Rules
                 return null;
             }
 
-            if (joinedLicenseExpression != null &&
-                LicensePlaceholder.TryGetByLicenseIdentifier(joinedLicenseExpression,
-                    out var licensePlaceholderFromExpression))
+            var containingLicencePlaceholder = LicensePlaceholder.ExtractContaining(joinedLicenseExpression);
+            if (containingLicencePlaceholder.Any())
             {
                 this.Logger.LogInformation(
-                    "Resolved no licenses for package: {PackageUrl} due to placeholder '{LicensePlaceholder}' in declared license and expression with license placeholder '{LicensePlaceholderFromExpression}'",
-                    packageUrl, licensePlaceholder.LicenseIdentifier, licensePlaceholderFromExpression!.LicenseIdentifier);
+                    "Resolved no licenses for package: {PackageUrl} due to placeholder '{LicensePlaceholder}' in declared license and expression with license placeholders '{LicensePlaceholderFromExpression}'",
+                    packageUrl, licensePlaceholder.LicenseIdentifier, string.Join(",", containingLicencePlaceholder));
                 return null;
             }
 


### PR DESCRIPTION
Now no license is resolved, when a declare license is a placeholder and the discovered licenses are also containing a placeholder.